### PR TITLE
fix docsify sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,9 @@
+* [Home](/)
+* Articles
+  * [Building Castles in the Sky](building-castles-in-the-sky.md)
+  * [The Quantum Coffee Machine](quantum-coffee-machine.md)
+  * [Gardens of Glass](gardens-of-glass.md)
+  * [YOLO](yolo.md)
+* Utilities
+  * [Live Location](live-location.html)
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,8 @@
   <script>
     window.$docsify = {
       name: 'codextest1',
-      repo: ''
+      repo: '',
+      loadSidebar: true
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>


### PR DESCRIPTION
## Summary
- enable sidebar loading in docsify config
- populate sidebar with links to articles and utilities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3728466883309f6a24dbce968acc